### PR TITLE
Cast to int/float with automatic detection of precision

### DIFF
--- a/src/gt4py/cartesian/frontend/defir_to_gtir.py
+++ b/src/gt4py/cartesian/frontend/defir_to_gtir.py
@@ -155,10 +155,13 @@ class UnrollVectorAssignments(IRNodeMapper):
             assign_list = []
             for index in itertools.product(*(range(dim) for dim in target_dims)):
                 tmp_node = copy.deepcopy(node)
-                value_node = functools.reduce(lambda arr, el: arr[el], index, unrolled_rhs)
+                value_node = functools.reduce(
+                    lambda arr, el: arr[el], index, unrolled_rhs
+                )
                 data_type = DataType.INT32
                 data_index = [
-                    ScalarLiteral(value=index_el, data_type=data_type) for index_el in index
+                    ScalarLiteral(value=index_el, data_type=data_type)
+                    for index_el in index
                 ]
 
                 tmp_node.target.data_index = data_index
@@ -172,16 +175,22 @@ class UnrollVectorAssignments(IRNodeMapper):
 
 class UnrollVectorExpressions(IRNodeMapper):
     @classmethod
-    def apply(cls, root, *, expected_dim: Tuple[int, ...], fields_decls: Dict[str, FieldDecl]):
+    def apply(
+        cls, root, *, expected_dim: Tuple[int, ...], fields_decls: Dict[str, FieldDecl]
+    ):
         result = cls().visit(root, fields_decls=fields_decls)
         # if the expression is just a scalar broadcast to the expected dimensions
         if not isinstance(result, list):
             result = functools.reduce(
-                lambda val, len_: [val for _ in range(len_)], reversed(expected_dim), result
+                lambda val, len_: [val for _ in range(len_)],
+                reversed(expected_dim),
+                result,
             )
         return result
 
-    def visit_FieldRef(self, node: FieldRef, *, fields_decls: Dict[str, FieldDecl], **kwargs):
+    def visit_FieldRef(
+        self, node: FieldRef, *, fields_decls: Dict[str, FieldDecl], **kwargs
+    ):
         name = node.name
         if fields_decls[name].data_dims:
             field_list = []
@@ -192,7 +201,10 @@ class UnrollVectorExpressions(IRNodeMapper):
                     data_type = DataType.INT32
                     data_index = [ScalarLiteral(value=index, data_type=data_type)]
                     element_ref = FieldRef(
-                        name=node.name, offset=node.offset, data_index=data_index, loc=node.loc
+                        name=node.name,
+                        offset=node.offset,
+                        data_index=data_index,
+                        loc=node.loc,
                     )
                     field_list.append(element_ref)
             # matrix
@@ -223,7 +235,9 @@ class UnrollVectorExpressions(IRNodeMapper):
 
         return node
 
-    def visit_UnaryOpExpr(self, node: UnaryOpExpr, *, fields_decls: Dict[str, FieldDecl], **kwargs):
+    def visit_UnaryOpExpr(
+        self, node: UnaryOpExpr, *, fields_decls: Dict[str, FieldDecl], **kwargs
+    ):
         if node.op == UnaryOperator.TRANSPOSED:
             node = self.visit(node.arg, fields_decls=fields_decls, **kwargs)
             assert isinstance(node, list) and all(
@@ -235,17 +249,25 @@ class UnrollVectorExpressions(IRNodeMapper):
 
         return self.generic_visit(node, **kwargs)
 
-    def visit_BinOpExpr(self, node: BinOpExpr, *, fields_decls: Dict[str, FieldDecl], **kwargs):
+    def visit_BinOpExpr(
+        self, node: BinOpExpr, *, fields_decls: Dict[str, FieldDecl], **kwargs
+    ):
         lhs = self.visit(node.lhs, fields_decls=fields_decls, **kwargs)
         rhs = self.visit(node.rhs, fields_decls=fields_decls, **kwargs)
         result: Union[List[BinOpExpr], BinOpExpr] = []
 
         if node.op == BinaryOperator.MATMULT:
             for j in range(len(lhs)):
-                acc = BinOpExpr(op=BinaryOperator.MUL, lhs=lhs[j][0], rhs=rhs[0], loc=node.loc)
+                acc = BinOpExpr(
+                    op=BinaryOperator.MUL, lhs=lhs[j][0], rhs=rhs[0], loc=node.loc
+                )
                 for i in range(1, len(lhs[0])):
-                    mul = BinOpExpr(op=BinaryOperator.MUL, lhs=lhs[j][i], rhs=rhs[i], loc=node.loc)
-                    acc = BinOpExpr(op=BinaryOperator.ADD, lhs=acc, rhs=mul, loc=node.loc)
+                    mul = BinOpExpr(
+                        op=BinaryOperator.MUL, lhs=lhs[j][i], rhs=rhs[i], loc=node.loc
+                    )
+                    acc = BinOpExpr(
+                        op=BinaryOperator.ADD, lhs=acc, rhs=mul, loc=node.loc
+                    )
 
                 result.append(acc)
         else:
@@ -253,14 +275,20 @@ class UnrollVectorExpressions(IRNodeMapper):
             if isinstance(lhs, list) and isinstance(rhs, list):
                 assert len(lhs) == len(rhs)
                 for lhs_el, rhs_el in zip(lhs, rhs):
-                    result.append(BinOpExpr(op=node.op, lhs=lhs_el, rhs=rhs_el, loc=node.loc))
+                    result.append(
+                        BinOpExpr(op=node.op, lhs=lhs_el, rhs=rhs_el, loc=node.loc)
+                    )
             # scalar and vector
             elif isinstance(lhs, Expr) and isinstance(rhs, list):
                 for rhs_el in rhs:
-                    result.append(BinOpExpr(op=node.op, lhs=lhs, rhs=rhs_el, loc=node.loc))
+                    result.append(
+                        BinOpExpr(op=node.op, lhs=lhs, rhs=rhs_el, loc=node.loc)
+                    )
             elif isinstance(lhs, list) and isinstance(rhs, Expr):
                 for lhs_el in lhs:
-                    result.append(BinOpExpr(op=node.op, lhs=lhs_el, rhs=rhs, loc=node.loc))
+                    result.append(
+                        BinOpExpr(op=node.op, lhs=lhs_el, rhs=rhs, loc=node.loc)
+                    )
             # scalar and scalar fallback
             else:
                 result = self.generic_visit(node, **kwargs)
@@ -369,7 +397,9 @@ class DefIRToGTIR(IRNodeVisitor):
                 gtir.Argument(
                     name=f.name,
                     is_keyword=f.is_keyword,
-                    default=str(f.default) if not isinstance(f.default, type(Empty)) else "",
+                    default=(
+                        str(f.default) if not isinstance(f.default, type(Empty)) else ""
+                    ),
                 )
                 for f in node.api_signature
             ],
@@ -384,7 +414,9 @@ class DefIRToGTIR(IRNodeVisitor):
             loc=location_to_source_location(node.loc),
         )
 
-    def visit_ArgumentInfo(self, node: ArgumentInfo, all_params: Dict[str, gtir.Decl]) -> gtir.Decl:
+    def visit_ArgumentInfo(
+        self, node: ArgumentInfo, all_params: Dict[str, gtir.Decl]
+    ) -> gtir.Decl:
         return all_params[node.name]
 
     def visit_ComputationBlock(self, node: ComputationBlock) -> gtir.VerticalLoop:
@@ -402,13 +434,17 @@ class DefIRToGTIR(IRNodeVisitor):
         )
         return gtir.VerticalLoop(
             interval=interval,
-            loop_order=self.GT4PY_ITERATIONORDER_TO_GTIR_LOOPORDER[node.iteration_order],
+            loop_order=self.GT4PY_ITERATIONORDER_TO_GTIR_LOOPORDER[
+                node.iteration_order
+            ],
             body=stmts,
             temporaries=temporaries,
             loc=location_to_source_location(node.loc),
         )
 
-    def visit_IteratorAccess(self, iterator_access: IteratorAccess) -> gtir.IteratorAccess:
+    def visit_IteratorAccess(
+        self, iterator_access: IteratorAccess
+    ) -> gtir.IteratorAccess:
         return gtir.IteratorAccess(name=gtir.IteratorAccess.AxisName("K"))
 
     def visit_BlockStmt(self, node: BlockStmt) -> List[gtir.Stmt]:
@@ -423,7 +459,9 @@ class DefIRToGTIR(IRNodeVisitor):
         )
 
     def visit_ScalarLiteral(self, node: ScalarLiteral) -> gtir.Literal:
-        return gtir.Literal(value=str(node.value), dtype=_convert_dtype(node.data_type.value))
+        return gtir.Literal(
+            value=str(node.value), dtype=_convert_dtype(node.data_type.value)
+        )
 
     def visit_UnaryOpExpr(self, node: UnaryOpExpr) -> gtir.UnaryOp:
         return gtir.UnaryOp(
@@ -432,7 +470,9 @@ class DefIRToGTIR(IRNodeVisitor):
             loc=location_to_source_location(node.loc),
         )
 
-    def visit_BinOpExpr(self, node: BinOpExpr) -> Union[gtir.BinaryOp, gtir.NativeFuncCall]:
+    def visit_BinOpExpr(
+        self, node: BinOpExpr
+    ) -> Union[gtir.BinaryOp, gtir.NativeFuncCall]:
         if node.op in (BinaryOperator.POW, BinaryOperator.MOD):
             return gtir.NativeFuncCall(
                 func=common.NativeFunction[node.op.name],
@@ -491,7 +531,9 @@ class DefIRToGTIR(IRNodeVisitor):
                 cond=cond,
                 true_branch=gtir.BlockStmt(body=self.visit(node.main_body)),
                 false_branch=(
-                    gtir.BlockStmt(body=self.visit(node.else_body)) if node.else_body else None
+                    gtir.BlockStmt(body=self.visit(node.else_body))
+                    if node.else_body
+                    else None
                 ),
                 loc=location_to_source_location(node.loc),
             )
@@ -500,7 +542,9 @@ class DefIRToGTIR(IRNodeVisitor):
                 cond=cond,
                 true_branch=gtir.BlockStmt(body=self.visit(node.main_body)),
                 false_branch=(
-                    gtir.BlockStmt(body=self.visit(node.else_body)) if node.else_body else None
+                    gtir.BlockStmt(body=self.visit(node.else_body))
+                    if node.else_body
+                    else None
                 ),
                 loc=location_to_source_location(node.loc),
             )
@@ -519,7 +563,9 @@ class DefIRToGTIR(IRNodeVisitor):
 
         axes = {
             axis.lower(): common.HorizontalInterval(
-                start=make_bound_or_level(node.intervals[axis].start, LevelMarker.START),
+                start=make_bound_or_level(
+                    node.intervals[axis].start, LevelMarker.START
+                ),
                 end=make_bound_or_level(node.intervals[axis].end, LevelMarker.END),
             )
             for axis in ("I", "J")
@@ -537,15 +583,20 @@ class DefIRToGTIR(IRNodeVisitor):
         )
 
     def visit_VarRef(self, node: VarRef, **kwargs):
-        return gtir.ScalarAccess(name=node.name, loc=location_to_source_location(node.loc))
+        return gtir.ScalarAccess(
+            name=node.name, loc=location_to_source_location(node.loc)
+        )
 
-    def visit_AxisInterval(self, node: AxisInterval) -> Tuple[gtir.AxisBound, gtir.AxisBound]:
+    def visit_AxisInterval(
+        self, node: AxisInterval
+    ) -> Tuple[gtir.AxisBound, gtir.AxisBound]:
         return self.visit(node.start), self.visit(node.end)
 
     def visit_AxisBound(self, node: AxisBound) -> gtir.AxisBound:
         # TODO(havogt) add support VarRef
         return gtir.AxisBound(
-            level=self.GT4PY_LEVELMARKER_TO_GTIR_LEVELMARKER[node.level], offset=node.offset
+            level=self.GT4PY_LEVELMARKER_TO_GTIR_LEVELMARKER[node.level],
+            offset=node.offset,
         )
 
     def visit_FieldDecl(self, node: FieldDecl) -> gtir.FieldDecl:
@@ -576,7 +627,9 @@ class DefIRToGTIR(IRNodeVisitor):
             return gtir.AbsoluteKIndex(k=k_to_gtir)
         k_val = offset.get("K", 0)
         if isinstance(k_val, numbers.Integral):
-            return common.CartesianOffset(i=offset.get("I", 0), j=offset.get("J", 0), k=k_val)
+            return common.CartesianOffset(
+                i=offset.get("I", 0), j=offset.get("J", 0), k=k_val
+            )
         elif isinstance(k_val, Expr):
             return gtir.VariableKOffset(k=self.visit(k_val, **kwargs))
         else:

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -344,7 +344,9 @@ class ReturnReplacer(gt_utils.meta.ASTTransformPass):
         """Ensure that there is only a single return statement (can still return a tuple)."""
         ret_count = sum(isinstance(node, ast.Return) for node in ast.walk(ast_object))
         if ret_count > 1:
-            raise GTScriptSyntaxError("GTScript Functions cannot have multiple return statements")
+            raise GTScriptSyntaxError(
+                "GTScript Functions cannot have multiple return statements"
+            )
         elif ret_count == 0 and target_node is not None:
             raise GTScriptSyntaxError(
                 "Attempting to assign the return value of a GTScript function that does not return anything."
@@ -470,7 +472,9 @@ class CallInliner(ast.NodeTransformer):
         elif isinstance(node, ast.Subscript):
             return self._get_sliced_symbol(node.value)
 
-    def visit_Call(self, node: ast.Call, *, target_node=None):  # Cyclomatic complexity too high
+    def visit_Call(
+        self, node: ast.Call, *, target_node=None
+    ):  # Cyclomatic complexity too high
         if _filter_absolute_K_index_method(node):
             return node
         call_name = gt_meta.get_qualified_name_from_node(node.func)
@@ -529,7 +533,9 @@ class CallInliner(ast.NodeTransformer):
         # Recursively inline any possible nested subroutine call
         self.current_name = call_name
         CallInliner.apply(
-            call_ast, call_info["local_context"], call_stack={*self.call_stack, call_name}
+            call_ast,
+            call_info["local_context"],
+            call_stack={*self.call_stack, call_name},
         )
 
         # Rename local names in subroutine to avoid conflicts with caller context names
@@ -547,10 +553,14 @@ class CallInliner(ast.NodeTransformer):
             if isinstance(target, ast.Subscript):
                 sliced_symbol = self._get_sliced_symbol(target)
                 if sliced_symbol not in call_args:
-                    raise GTScriptSyntaxError(message="Unsupported assignment target.", loc=target)
+                    raise GTScriptSyntaxError(
+                        message="Unsupported assignment target.", loc=target
+                    )
             else:
                 if not isinstance(target, ast.Name):
-                    raise GTScriptSyntaxError(message="Unsupported assignment target.", loc=target)
+                    raise GTScriptSyntaxError(
+                        message="Unsupported assignment target.", loc=target
+                    )
 
                 assigned_symbols.add(target.id)
 
@@ -573,7 +583,9 @@ class CallInliner(ast.NodeTransformer):
 
         # Replace returns by assignments in subroutine
         if target_node is None:
-            return_nodes = [nd for nd in ast.walk(call_ast) if isinstance(nd, ast.Return)]
+            return_nodes = [
+                nd for nd in ast.walk(call_ast) if isinstance(nd, ast.Return)
+            ]
             if any(isinstance(nd.value, ast.Tuple) for nd in return_nodes):
                 raise GTScriptSyntaxError(
                     "Only functions with a single return value can be used in expressions, including as call arguments. "
@@ -658,7 +670,8 @@ class CallInliner(ast.NodeTransformer):
     def visit_Expr(self, node: ast.Expr):
         if (
             isinstance(node.value, ast.Call)
-            and gt_meta.get_qualified_name_from_node(node.value.func) not in gtscript.MATH_BUILTINS
+            and gt_meta.get_qualified_name_from_node(node.value.func)
+            not in gtscript.MATH_BUILTINS
         ):
             # Inline a function with no return value and then remove the current node
             self.visit(node.value, target_node=None)
@@ -719,7 +732,11 @@ class LoopIndexReplacer(ast.NodeTransformer):
 def _get_loop_index_values(
     node: Union[ast.Call, ast.List, ast.Tuple], context: dict
 ) -> Optional[Union[list, range]]:
-    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "range":
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "range"
+    ):
         range_args = [eval(ast.unparse(arg), context) for arg in node.args]
         assert 1 <= len(range_args) <= 3
         if len(range_args) == 1:
@@ -767,7 +784,10 @@ class ReductionUnroller(ast.NodeTransformer):
         if not 2 <= len(args) <= 3:
             raise GTScriptSyntaxError("Reduce: the function takes 2 to 3 arguments.")
 
-        if isinstance(args[0], ast.Name) and (op_id := args[0].id) in self.REDUCTION_OP_TO_AST_OP:
+        if (
+            isinstance(args[0], ast.Name)
+            and (op_id := args[0].id) in self.REDUCTION_OP_TO_AST_OP
+        ):
             op = self.REDUCTION_OP_TO_AST_OP[op_id]()
         else:
             raise GTScriptSyntaxError("Reduce: invalid reduction operator.")
@@ -779,7 +799,9 @@ class ReductionUnroller(ast.NodeTransformer):
                 _get_loop_index_values(generator_expr.generators[0].iter, self.context)
             )
         else:
-            raise GTScriptSyntaxError("Reduce: second argument should be a generator expression.")
+            raise GTScriptSyntaxError(
+                "Reduce: second argument should be a generator expression."
+            )
 
         initial_value = args[2] if len(node.args) == 3 else None
 
@@ -787,7 +809,9 @@ class ReductionUnroller(ast.NodeTransformer):
             op, template_item, index_name, index_values, left=initial_value
         )
 
-    def _get_binary_node(self, op, template_item, index_name, index_values, left=None) -> ast.BinOp:
+    def _get_binary_node(
+        self, op, template_item, index_name, index_values, left=None
+    ) -> ast.BinOp:
         if left is None:
             assert len(index_values) > 1
             left = LoopIndexReplacer(index_name, index_values[0]).visit(
@@ -820,7 +844,9 @@ class DataDimLoopUnroller(ast.NodeTransformer):
     def visit_For(self, node: ast.For) -> Union[ast.For, list[ast.AST]]:
         super().generic_visit(node)
 
-        if (index_values := _get_loop_index_values(node.iter, self.context)) is not None:
+        if (
+            index_values := _get_loop_index_values(node.iter, self.context)
+        ) is not None:
             assert isinstance(node.target, ast.Name)
             index_name = node.target.id
 
@@ -1019,7 +1045,7 @@ class IRMaker(ast.NodeVisitor):
             ),
             "float": (
                 nodes.NativeFunction.F32
-                if int(os.getenv("GT4PY_LITERAL_PRECISION", "64")) == "32"
+                if int(os.getenv("GT4PY_LITERAL_PRECISION", "64")) == 32
                 else nodes.NativeFunction.F64
             ),
         }

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -16,7 +16,20 @@ import textwrap
 import time
 import types
 import warnings
-from typing import Any, Dict, Final, List, Literal, Optional, Sequence, Set, Tuple, Type, Union
+import os
+from typing import (
+    Any,
+    Dict,
+    Final,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 import numpy as np
 
@@ -54,7 +67,9 @@ class AssertionChecker(ast.NodeTransformer):
         self.source = source
 
     def _process_assertion(self, expr_node: ast.Expr) -> None:
-        condition_value = gt_utils.meta.ast_eval(expr_node, self.context, default=NOTHING)
+        condition_value = gt_utils.meta.ast_eval(
+            expr_node, self.context, default=NOTHING
+        )
         if condition_value is not NOTHING:
             if not condition_value:
                 source_lines = textwrap.dedent(self.source).split("\n")
@@ -150,7 +165,8 @@ class AxisIntervalParser(gt_meta.ASTPass):
     def slice_from_value(node: ast.Expr) -> ast.Slice:
         """Create an ast.Slice node from a general ast.Expr node."""
         slice_node = ast.Slice(
-            lower=node, upper=ast.BinOp(left=node, op=ast.Add(), right=ast.Constant(value=1))
+            lower=node,
+            upper=ast.BinOp(left=node, op=ast.Add(), right=ast.Constant(value=1)),
         )
         slice_node = ast.copy_location(slice_node, node)
         return slice_node
@@ -170,7 +186,11 @@ class AxisIntervalParser(gt_meta.ASTPass):
                 level = value
                 offset = 0
             elif isinstance(value, gtscript.AxisIndex):
-                level = nodes.LevelMarker.START if value.index >= 0 else nodes.LevelMarker.END
+                level = (
+                    nodes.LevelMarker.START
+                    if value.index >= 0
+                    else nodes.LevelMarker.END
+                )
                 offset = value.index + value.offset
             elif value is None:
                 LARGE_NUM = 10000
@@ -179,7 +199,9 @@ class AxisIntervalParser(gt_meta.ASTPass):
                 if self.axis_name == seq_name:
                     offset = 0
                 else:
-                    offset = -LARGE_NUM if level == nodes.LevelMarker.START else LARGE_NUM
+                    offset = (
+                        -LARGE_NUM if level == nodes.LevelMarker.START else LARGE_NUM
+                    )
             else:
                 raise self.interval_error
 
@@ -188,7 +210,9 @@ class AxisIntervalParser(gt_meta.ASTPass):
     def visit_Name(self, node: ast.Name) -> nodes.VarRef:
         return nodes.VarRef(name=node.id, loc=nodes.Location.from_ast_node(node))
 
-    def visit_Constant(self, node: ast.Constant) -> Union[int, gtscript.AxisIndex, None]:
+    def visit_Constant(
+        self, node: ast.Constant
+    ) -> Union[int, gtscript.AxisIndex, None]:
         if isinstance(node.value, gtscript.AxisIndex):
             return node.value
         elif isinstance(node.value, numbers.Number):
@@ -201,7 +225,9 @@ class AxisIntervalParser(gt_meta.ASTPass):
                 loc=self.loc,
             )
 
-    def visit_BinOp(self, node: ast.BinOp) -> Union[gtscript.AxisIndex, nodes.AxisBound, int]:
+    def visit_BinOp(
+        self, node: ast.BinOp
+    ) -> Union[gtscript.AxisIndex, nodes.AxisBound, int]:
         left = self.visit(node.left)
         right = self.visit(node.right)
 
@@ -212,12 +238,16 @@ class AxisIntervalParser(gt_meta.ASTPass):
             bin_op = lambda x, y: x - y  # noqa: E731 [lambda-assignment]
             u_op = lambda x: -x  # noqa: E731 [lambda-assignment]
         elif isinstance(node.op, ast.Mult):
-            if left.level != right.level or not isinstance(left.level, nodes.LevelMarker):
+            if left.level != right.level or not isinstance(
+                left.level, nodes.LevelMarker
+            ):
                 raise self.interval_error
             bin_op = lambda x, y: x * y  # noqa: E731 [lambda-assignment]
             u_op = None
         else:
-            raise GTScriptSyntaxError("Unexpected binary operator found in interval expression")
+            raise GTScriptSyntaxError(
+                "Unexpected binary operator found in interval expression"
+            )
 
         incompatible_types_error = GTScriptSyntaxError(
             "Incompatible types found in interval expression"
@@ -355,7 +385,11 @@ class CallInliner(ast.NodeTransformer):
 
     @classmethod
     def apply(
-        cls, func_node: ast.FunctionDef, context: dict, *, call_stack: Optional[Set[str]] = None
+        cls,
+        func_node: ast.FunctionDef,
+        context: dict,
+        *,
+        call_stack: Optional[Set[str]] = None,
     ):
         inliner = cls(context, call_stack=call_stack or set())
         inliner(func_node)
@@ -451,8 +485,12 @@ class CallInliner(ast.NodeTransformer):
         if call_name in gtscript.IGNORE_WHEN_INLINING:
             # Not a function to inline, return as-is.
             return node
-        elif call_name not in self.context or not hasattr(self.context[call_name], "_gtscript_"):
-            raise GTScriptSyntaxError("Unknown call", loc=nodes.Location.from_ast_node(node))
+        elif call_name not in self.context or not hasattr(
+            self.context[call_name], "_gtscript_"
+        ):
+            raise GTScriptSyntaxError(
+                "Unknown call", loc=nodes.Location.from_ast_node(node)
+            )
 
         # Extract call arguments
         call_info = self.context[call_name]._gtscript_
@@ -496,7 +534,9 @@ class CallInliner(ast.NodeTransformer):
 
         # Rename local names in subroutine to avoid conflicts with caller context names
         try:
-            assign_targets = gt_meta.collect_assign_targets(call_ast, allow_multiple_targets=False)
+            assign_targets = gt_meta.collect_assign_targets(
+                call_ast, allow_multiple_targets=False
+            )
         except RuntimeError as e:
             raise GTScriptSyntaxError(
                 message="Assignment to more than one target is not supported."
@@ -525,7 +565,10 @@ class CallInliner(ast.NodeTransformer):
         template_fmt = "{name}__" + call_id_suffix
 
         gt_meta.map_symbol_names(
-            call_ast, name_mapping, template_fmt=template_fmt, skip_names=self.all_skip_names
+            call_ast,
+            name_mapping,
+            template_fmt=template_fmt,
+            skip_names=self.all_skip_names,
         )
 
         # Replace returns by assignments in subroutine
@@ -648,7 +691,9 @@ class CompiledIfInliner(ast.NodeTransformer):
                 category=DeprecationWarning,
             )
             eval_node = node.test.args[0]
-            condition_value = gt_utils.meta.ast_eval(eval_node, self.context, default=NOTHING)
+            condition_value = gt_utils.meta.ast_eval(
+                eval_node, self.context, default=NOTHING
+            )
             if condition_value is not NOTHING:
                 node = node.body if condition_value else node.orelse
             else:
@@ -807,7 +852,9 @@ def _make_temp_decls(
 
 
 def _make_init_computations(
-    temp_decls: Dict[str, nodes.FieldDecl], init_values: Dict[str, Any], func_node: ast.AST
+    temp_decls: Dict[str, nodes.FieldDecl],
+    init_values: Dict[str, Any],
+    func_node: ast.AST,
 ) -> List[nodes.ComputationBlock]:
     if not temp_decls:
         return []
@@ -819,7 +866,8 @@ def _make_init_computations(
         if decl.data_dims:
             for index in itertools.product(*(range(i) for i in decl.data_dims)):
                 literal_index = [
-                    nodes.ScalarLiteral(value=i, data_type=nodes.DataType.INT32) for i in index
+                    nodes.ScalarLiteral(value=i, data_type=nodes.DataType.INT32)
+                    for i in index
                 ]
                 stmts.append(
                     nodes.Assign(
@@ -834,7 +882,8 @@ def _make_init_computations(
         else:
             stmts.append(
                 nodes.Assign(
-                    target=nodes.FieldRef.at_center(name, axes=decl.axes), value=init_values[name]
+                    target=nodes.FieldRef.at_center(name, axes=decl.axes),
+                    value=init_values[name],
                 )
             )
 
@@ -886,6 +935,13 @@ def _is_datadims_indexing_node(node):
         and node.value.attr == _DATADIMS_INDEXER
         and isinstance(node.value.value, ast.Name)
     )
+
+
+# def test_function():
+#     if int(os.getenv("PACE_FLOAT_PRECISION", "64")) == 32:
+#         return nodes.NativeFunction.I32
+#     else:
+#         return nodes.NativeFunction.I64
 
 
 class IRMaker(ast.NodeVisitor):
@@ -956,6 +1012,16 @@ class IRMaker(ast.NodeVisitor):
             "i64": nodes.NativeFunction.I64,
             "f32": nodes.NativeFunction.F32,
             "f64": nodes.NativeFunction.F64,
+            "int": (
+                nodes.NativeFunction.I32
+                if int(os.getenv("GT4PY_LITERAL_PRECISION", "64")) == 32
+                else nodes.NativeFunction.I64
+            ),
+            "float": (
+                nodes.NativeFunction.F32
+                if int(os.getenv("GT4PY_LITERAL_PRECISION", "64")) == "32"
+                else nodes.NativeFunction.F64
+            ),
         }
 
     def __call__(self, ast_root: ast.AST):
@@ -982,7 +1048,11 @@ class IRMaker(ast.NodeVisitor):
         return name in self.local_symbols
 
     def _is_known(self, name: str):
-        return self._is_field(name) or self._is_parameter(name) or self._is_local_symbol(name)
+        return (
+            self._is_field(name)
+            or self._is_parameter(name)
+            or self._is_local_symbol(name)
+        )
 
     def _are_blocks_sorted(self, compute_blocks: List[nodes.ComputationBlock]):
         def sort_blocks_key(comp_block):
@@ -1015,7 +1085,9 @@ class IRMaker(ast.NodeVisitor):
         return compute_blocks == compute_blocks_sorted
 
     def _parse_region_intervals(
-        self, node: Union[ast.ExtSlice, ast.Index, ast.Tuple], loc: nodes.Location = None
+        self,
+        node: Union[ast.ExtSlice, ast.Index, ast.Tuple],
+        loc: nodes.Location = None,
     ) -> Dict[str, nodes.AxisInterval]:
         if isinstance(node, ast.Index):
             # Python 3.8 wraps a Tuple in an Index for region[0, 1]
@@ -1031,7 +1103,8 @@ class IRMaker(ast.NodeVisitor):
             ]
         else:
             raise GTScriptSyntaxError(
-                f"Invalid 'region' index at line {loc.line} (column {loc.column})", loc=loc
+                f"Invalid 'region' index at line {loc.line} (column {loc.column})",
+                loc=loc,
             )
         axes_names = [axis.name for axis in self.domain.parallel_axes]
         return {
@@ -1043,7 +1116,8 @@ class IRMaker(ast.NodeVisitor):
         self, node: ast.withitem, loc: nodes.Location
     ) -> List[Dict[str, nodes.AxisInterval]]:
         syntax_error = GTScriptSyntaxError(
-            f"Invalid 'with' statement at line {loc.line} (column {loc.column})", loc=loc
+            f"Invalid 'with' statement at line {loc.line} (column {loc.column})",
+            loc=loc,
         )
 
         call_args = node.context_expr.args
@@ -1054,7 +1128,9 @@ class IRMaker(ast.NodeVisitor):
 
         return [self._parse_region_intervals(arg.slice, loc) for arg in call_args]
 
-    def _are_intervals_nonoverlapping(self, compute_blocks: List[nodes.ComputationBlock]):
+    def _are_intervals_nonoverlapping(
+        self, compute_blocks: List[nodes.ComputationBlock]
+    ):
         for i, block in enumerate(compute_blocks[1:]):
             other = compute_blocks[i]
             if not block.interval.disjoint_from(other.interval):
@@ -1063,7 +1139,8 @@ class IRMaker(ast.NodeVisitor):
 
     def _visit_iteration_order_node(self, node: ast.withitem, loc: nodes.Location):
         syntax_error = GTScriptSyntaxError(
-            f"Invalid 'computation' specification at line {loc.line} (column {loc.column})", loc=loc
+            f"Invalid 'computation' specification at line {loc.line} (column {loc.column})",
+            loc=loc,
         )
         comp_node = node.context_expr
         if len(comp_node.args) + len(comp_node.keywords) != 1 or any(
@@ -1125,7 +1202,8 @@ class IRMaker(ast.NodeVisitor):
     def _visit_computation_node(self, node: ast.With) -> nodes.ComputationBlock:
         loc = nodes.Location.from_ast_node(node)
         syntax_error = GTScriptSyntaxError(
-            f"Invalid 'computation' specification at line {loc.line} (column {loc.column})", loc=loc
+            f"Invalid 'computation' specification at line {loc.line} (column {loc.column})",
+            loc=loc,
         )
 
         # Parse computation specification, i.e. `withItems` nodes
@@ -1244,7 +1322,9 @@ class IRMaker(ast.NodeVisitor):
         symbol = node.id
         if self._is_field(symbol):
             result = nodes.FieldRef.at_center(
-                symbol, axes=self.fields[symbol].axes, loc=nodes.Location.from_ast_node(node)
+                symbol,
+                axes=self.fields[symbol].axes,
+                loc=nodes.Location.from_ast_node(node),
             )
         elif self._is_parameter(symbol):
             result = nodes.VarRef(name=symbol, loc=nodes.Location.from_ast_node(node))
@@ -1252,7 +1332,8 @@ class IRMaker(ast.NodeVisitor):
             raise AssertionError("Logic error")
         elif _is_datadims_indexing_name(symbol):
             result = nodes.FieldRef.datadims_index(
-                name=_trim_indexing_symbol(symbol), loc=nodes.Location.from_ast_node(node)
+                name=_trim_indexing_symbol(symbol),
+                loc=nodes.Location.from_ast_node(node),
             )
         elif _is_iterator_access(symbol):
             return nodes.IteratorAccess()
@@ -1266,12 +1347,16 @@ class IRMaker(ast.NodeVisitor):
         return index
 
     def _eval_new_spatial_index(
-        self, index_nodes: Sequence[nodes.Expr], field_axes: Optional[Set[Literal["I", "J", "K"]]]
+        self,
+        index_nodes: Sequence[nodes.Expr],
+        field_axes: Optional[Set[Literal["I", "J", "K"]]],
     ) -> List[int]:
         index_dict = {}
         all_spatial_axes = ("I", "J", "K")
         last_index = -1
-        axis_context = {axis: gtscript.ShiftedAxis(name=axis, shift=0) for axis in field_axes}
+        axis_context = {
+            axis: gtscript.ShiftedAxis(name=axis, shift=0) for axis in field_axes
+        }
 
         for index_node in index_nodes:
             try:
@@ -1293,7 +1378,8 @@ class IRMaker(ast.NodeVisitor):
                     )
                 elif axis_index < last_index:
                     raise GTScriptSyntaxError(
-                        message=f"Axis {value.name} is specified out of order", loc=index_node
+                        message=f"Axis {value.name} is specified out of order",
+                        loc=index_node,
                     )
                 elif axis_index == last_index:
                     raise GTScriptSyntaxError(
@@ -1307,14 +1393,22 @@ class IRMaker(ast.NodeVisitor):
                     shift = 0
                 index_dict[value.name] = shift
 
-        return [index_dict.get(axis, 0) for axis in ("I", "J", "K") if axis in field_axes]
+        return [
+            index_dict.get(axis, 0) for axis in ("I", "J", "K") if axis in field_axes
+        ]
 
     def _eval_index(
-        self, node: ast.Subscript, field_axes: Optional[Set[Literal["I", "J", "K"]]] = None
+        self,
+        node: ast.Subscript,
+        field_axes: Optional[Set[Literal["I", "J", "K"]]] = None,
     ) -> Optional[Union[List[int], nodes.AbsoluteKIndex]]:
-        tuple_or_expr = node.slice.value if isinstance(node.slice, ast.Index) else node.slice
+        tuple_or_expr = (
+            node.slice.value if isinstance(node.slice, ast.Index) else node.slice
+        )
         index_nodes = gtc_utils.listify(
-            tuple_or_expr.elts if isinstance(tuple_or_expr, ast.Tuple) else tuple_or_expr
+            tuple_or_expr.elts
+            if isinstance(tuple_or_expr, ast.Tuple)
+            else tuple_or_expr
         )
 
         if any(isinstance(cn, ast.Slice) for cn in index_nodes):
@@ -1326,7 +1420,9 @@ class IRMaker(ast.NodeVisitor):
         # If this is parsing a data index, this should be fine and will return False.
         new_style_spatial_syntax = field_axes is not None and any(
             (isinstance(node, ast.Name) and node.id in field_axes)
-            or (isinstance(node, ast.Constant) and isinstance(node.value, gtscript.Axis))
+            or (
+                isinstance(node, ast.Constant) and isinstance(node.value, gtscript.Axis)
+            )
             for index_node in index_nodes
             for node in ast.walk(index_node)
         )
@@ -1368,14 +1464,20 @@ class IRMaker(ast.NodeVisitor):
                     if len(field_axes) != len(index):
                         ro_field_message = ""
                         if len(field_axes) == 0:
-                            ro_field_message = f"Did you mean absolute indexing via .A{index}?"
+                            ro_field_message = (
+                                f"Did you mean absolute indexing via .A{index}?"
+                            )
                         raise GTScriptSyntaxError(
                             f"Incorrect offset specification detected for {result.name}. "
                             f"Found index={index}, but {result.name} field has dimensions ({', '.join(field_axes)}). "
                             f"{ro_field_message}"
                         )
-                    result.offset = {axis: value for axis, value in zip(field_axes, index)}
-            elif isinstance(node.value, ast.Subscript) or _is_datadims_indexing_node(node):
+                    result.offset = {
+                        axis: value for axis, value in zip(field_axes, index)
+                    }
+            elif isinstance(node.value, ast.Subscript) or _is_datadims_indexing_node(
+                node
+            ):
                 result.data_index = [
                     (
                         nodes.ScalarLiteral(value=value, data_type=nodes.DataType.INT32)
@@ -1404,7 +1506,8 @@ class IRMaker(ast.NodeVisitor):
                     )
             else:
                 raise GTScriptSyntaxError(
-                    "Unrecognized subscript expression", loc=nodes.Location.from_ast_node(node)
+                    "Unrecognized subscript expression",
+                    loc=nodes.Location.from_ast_node(node),
                 )
 
         return result
@@ -1416,7 +1519,9 @@ class IRMaker(ast.NodeVisitor):
         if isinstance(arg, numbers.Number):
             result = eval("{op}{arg}".format(op=op.python_symbol, arg=arg))
         else:
-            result = nodes.UnaryOpExpr(op=op, arg=arg, loc=nodes.Location.from_ast_node(node))
+            result = nodes.UnaryOpExpr(
+                op=op, arg=arg, loc=nodes.Location.from_ast_node(node)
+            )
 
         return result
 
@@ -1487,7 +1592,9 @@ class IRMaker(ast.NodeVisitor):
         rhs = self.visit(node.values[-1])
         for value in reversed(node.values[:-1]):
             lhs = self.visit(value)
-            rhs = nodes.BinOpExpr(op=op, lhs=lhs, rhs=rhs, loc=nodes.Location.from_ast_node(node))
+            rhs = nodes.BinOpExpr(
+                op=op, lhs=lhs, rhs=rhs, loc=nodes.Location.from_ast_node(node)
+            )
             res = rhs
 
         return res
@@ -1503,11 +1610,15 @@ class IRMaker(ast.NodeVisitor):
 
         for i in range(len(node.comparators) - 2, -1, -1):
             lhs = self.visit(node.values[i])
-            rhs = nodes.BinOpExpr(op=op, lhs=lhs, rhs=rhs, loc=nodes.Location.from_ast_node(node))
+            rhs = nodes.BinOpExpr(
+                op=op, lhs=lhs, rhs=rhs, loc=nodes.Location.from_ast_node(node)
+            )
             op = self.visit(node.ops[i])
             args.append(lhs)
 
-        result = nodes.BinOpExpr(op=op, lhs=lhs, rhs=rhs, loc=nodes.Location.from_ast_node(node))
+        result = nodes.BinOpExpr(
+            op=op, lhs=lhs, rhs=rhs, loc=nodes.Location.from_ast_node(node)
+        )
 
         return result
 
@@ -1545,9 +1656,13 @@ class IRMaker(ast.NodeVisitor):
             nodes.If(
                 condition=self.visit(node.test),
                 loc=nodes.Location.from_ast_node(node),
-                main_body=nodes.BlockStmt(stmts=main_stmts, loc=nodes.Location.from_ast_node(node)),
+                main_body=nodes.BlockStmt(
+                    stmts=main_stmts, loc=nodes.Location.from_ast_node(node)
+                ),
                 else_body=(
-                    nodes.BlockStmt(stmts=else_stmts, loc=nodes.Location.from_ast_node(node))
+                    nodes.BlockStmt(
+                        stmts=else_stmts, loc=nodes.Location.from_ast_node(node)
+                    )
                     if else_stmts
                     else None
                 ),
@@ -1616,7 +1731,9 @@ class IRMaker(ast.NodeVisitor):
         assert isinstance(field, nodes.FieldRef)
         field.offset = nodes.AbsoluteKIndex(k=self.visit(node.keywords[0].value))
         if len(node.keywords) == 2:
-            field.data_index = [self.visit(value) for value in node.keywords[1].value.elts]
+            field.data_index = [
+                self.visit(value) for value in node.keywords[1].value.elts
+            ]
         return field
 
     def visit_Call(self, node: ast.Call):
@@ -1672,7 +1789,9 @@ class IRMaker(ast.NodeVisitor):
         return name, spatial_offset, data_index
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> list:
-        return self._resolve_assign(node, [node.target], target_annotation=node.annotation)
+        return self._resolve_assign(
+            node, [node.target], target_annotation=node.annotation
+        )
 
     def visit_Assign(self, node: ast.Assign, **kwargs) -> list:
         return self._resolve_assign(node, node.targets)
@@ -1752,7 +1871,9 @@ class IRMaker(ast.NodeVisitor):
                 self.written_vars.add(name)
 
             axes = self.fields[name].axes
-            par_axes_names = [axis.name for axis in nodes.Domain.LatLonGrid().parallel_axes]
+            par_axes_names = [
+                axis.name for axis in nodes.Domain.LatLonGrid().parallel_axes
+            ]
             if self.iteration_order == nodes.IterationOrder.PARALLEL:
                 par_axes_names.append(nodes.Domain.LatLonGrid().sequential_axis.name)
             if set(par_axes_names) - set(axes):
@@ -1768,7 +1889,9 @@ class IRMaker(ast.NodeVisitor):
         assert len(target) == len(value)
         for left, right in zip(target, value):
             result.append(
-                nodes.Assign(target=left, value=right, loc=nodes.Location.from_ast_node(node))
+                nodes.Assign(
+                    target=left, value=right, loc=nodes.Location.from_ast_node(node)
+                )
             )
 
         return result
@@ -1784,7 +1907,8 @@ class IRMaker(ast.NodeVisitor):
     def visit_With(self, node: ast.With):
         loc = nodes.Location.from_ast_node(node)
         syntax_error = GTScriptSyntaxError(
-            f"Invalid 'with' statement at line {loc.line} (column {loc.column})", loc=loc
+            f"Invalid 'with' statement at line {loc.line} (column {loc.column})",
+            loc=loc,
         )
 
         if (
@@ -1793,7 +1917,9 @@ class IRMaker(ast.NodeVisitor):
             and node.items[0].context_expr.func.id == "horizontal"
         ):
             if any(isinstance(child_node, ast.With) for child_node in node.body):
-                raise GTScriptSyntaxError("Cannot nest `with` node inside horizontal region")
+                raise GTScriptSyntaxError(
+                    "Cannot nest `with` node inside horizontal region"
+                )
 
             self.parsing_horizontal_region = True
             intervals_dicts = self._visit_with_horizontal(node.items[0], loc)
@@ -1803,7 +1929,9 @@ class IRMaker(ast.NodeVisitor):
             self.parsing_horizontal_region = False
             stmts = list(filter(lambda stmt: isinstance(stmt, nodes.Decl), all_stmts))
             body_block = nodes.BlockStmt(
-                stmts=list(filter(lambda stmt: not isinstance(stmt, nodes.Decl), all_stmts)),
+                stmts=list(
+                    filter(lambda stmt: not isinstance(stmt, nodes.Decl), all_stmts)
+                ),
                 loc=loc,
             )
             names = _find_accesses_with_offsets(body_block)
@@ -1845,7 +1973,9 @@ class IRMaker(ast.NodeVisitor):
                 # Parse nested `with` blocks
                 compute_blocks = []
                 for with_node in node.body:
-                    with_node = copy.deepcopy(with_node)  # Copy to avoid altering original ast
+                    with_node = copy.deepcopy(
+                        with_node
+                    )  # Copy to avoid altering original ast
                     # Splice `withItems` of current/primary with statement into nested with
                     with_node.items.extend(node.items)
 
@@ -1912,7 +2042,9 @@ class CollectLocalSymbolsAstVisitor(ast.NodeVisitor):
                             message="writing to an GlobalTable ('A' global indexation) is forbidden",
                             loc=nodes.Location.from_ast_node(node),
                         )
-                    elif isinstance(t.value, ast.Subscript) and isinstance(t.value.value, ast.Name):
+                    elif isinstance(t.value, ast.Subscript) and isinstance(
+                        t.value.value, ast.Name
+                    ):
                         name_node = t.value.value
                     else:
                         raise invalid_target
@@ -1947,7 +2079,9 @@ class GTScriptParser(ast.NodeVisitor):
 
     def __str__(self) -> str:
         result = "<GT4Py.GTScriptParser> {\n"
-        result += "\n".join("\t{}: {}".format(name, getattr(self, name)) for name in vars(self))
+        result += "\n".join(
+            "\t{}: {}".format(name, getattr(self, name)) for name in vars(self)
+        )
         result += "\n}"
         return result
 
@@ -2001,14 +2135,22 @@ class GTScriptParser(ast.NodeVisitor):
                     )
 
                 api_signature.append(
-                    nodes.ArgumentInfo(name=param.name, is_keyword=is_keyword, default=default)
+                    nodes.ArgumentInfo(
+                        name=param.name, is_keyword=is_keyword, default=default
+                    )
                 )
 
                 api_annotations.append(dtype_annotation)
 
-        nonlocal_symbols, imported_symbols = GTScriptParser.collect_external_symbols(definition)
-        ast_func_def = gt_meta.get_ast(definition, feature_version=PYTHON_AST_VERSION).body[0]
-        canonical_ast = gt_meta.ast_dump(ast_func_def, feature_version=PYTHON_AST_VERSION)
+        nonlocal_symbols, imported_symbols = GTScriptParser.collect_external_symbols(
+            definition
+        )
+        ast_func_def = gt_meta.get_ast(
+            definition, feature_version=PYTHON_AST_VERSION
+        ).body[0]
+        canonical_ast = gt_meta.ast_dump(
+            ast_func_def, feature_version=PYTHON_AST_VERSION
+        )
 
         # resolve externals
         if externals is not None:
@@ -2033,7 +2175,9 @@ class GTScriptParser(ast.NodeVisitor):
             **(resolved_externals if externals is not None else nonlocal_symbols),
             **nodes.DataType.FRONTEND_TO_NATIVE,
         }
-        ann_assigns = tuple(filter(lambda stmt: isinstance(stmt, ast.AnnAssign), ast_func_def.body))
+        ann_assigns = tuple(
+            filter(lambda stmt: isinstance(stmt, ast.AnnAssign), ast_func_def.body)
+        )
         for ann_assign in ann_assigns:
             assert isinstance(ann_assign.target, ast.Name)
             name = ann_assign.target.id
@@ -2097,7 +2241,9 @@ class GTScriptParser(ast.NodeVisitor):
                     wrong_imports.append(key)
 
         if wrong_imports:
-            raise GTScriptSyntaxError("Invalid 'import' statements ({})".format(wrong_imports))
+            raise GTScriptSyntaxError(
+                "Invalid 'import' statements ({})".format(wrong_imports)
+            )
 
         context, unbound = gt_meta.get_closure(
             definition, included_nonlocals=True, include_builtins=False
@@ -2152,7 +2298,9 @@ class GTScriptParser(ast.NodeVisitor):
             raise GTScriptDefinitionError(
                 name=name,
                 value="<unknown>",
-                message="Missing or invalid value for external symbol {name}".format(name=name),
+                message="Missing or invalid value for external symbol {name}".format(
+                    name=name
+                ),
                 loc=loc,
             ) from e
         return value
@@ -2189,20 +2337,28 @@ class GTScriptParser(ast.NodeVisitor):
                             (
                                 attr_name,
                                 GTScriptParser.eval_external(
-                                    attr_name, context, nodes.Location.from_ast_node(attr_nodes[0])
+                                    attr_name,
+                                    context,
+                                    nodes.Location.from_ast_node(attr_nodes[0]),
                                 ),
                             )
                         )
 
                 elif not exhaustive:
-                    resolved_values_list.append((name, GTScriptParser.eval_external(name, context)))
+                    resolved_values_list.append(
+                        (name, GTScriptParser.eval_external(name, context))
+                    )
 
             for _, value in resolved_values_list:
                 if hasattr(value, "_gtscript_") and exhaustive:
                     assert callable(value)
                     nested_inlined_values = {
-                        "{}.{}".format(value._gtscript_["qualified_name"], item_name): item_value
-                        for item_name, item_value in value._gtscript_["nonlocals"].items()
+                        "{}.{}".format(
+                            value._gtscript_["qualified_name"], item_name
+                        ): item_value
+                        for item_name, item_value in value._gtscript_[
+                            "nonlocals"
+                        ].items()
                     }
                     resolved_values_list.extend(nested_inlined_values.items())
 
@@ -2239,7 +2395,8 @@ class GTScriptParser(ast.NodeVisitor):
         for arg_info, arg_annotation in zip(api_signature, api_annotations):
             try:
                 assert arg_annotation in gtscript._VALID_DATA_TYPES or isinstance(
-                    arg_annotation, (gtscript._SequenceDescriptor, gtscript._FieldDescriptor)
+                    arg_annotation,
+                    (gtscript._SequenceDescriptor, gtscript._FieldDescriptor),
                 ), "Invalid parameter annotation"
 
                 if arg_annotation in gtscript._VALID_DATA_TYPES:
@@ -2255,12 +2412,17 @@ class GTScriptParser(ast.NodeVisitor):
                     data_type = nodes.DataType.from_dtype(np.dtype(arg_annotation))
                     length = arg_annotation.length
                     parameter_decls[arg_info.name] = nodes.VarDecl(
-                        name=arg_info.name, data_type=data_type, length=length, is_api=True
+                        name=arg_info.name,
+                        data_type=data_type,
+                        length=length,
+                        is_api=True,
                     )
                 else:
                     assert isinstance(arg_annotation, gtscript._FieldDescriptor)
                     assert arg_info.default in [nodes.Empty, None]
-                    data_type = nodes.DataType.from_dtype(np.dtype(arg_annotation.dtype))
+                    data_type = nodes.DataType.from_dtype(
+                        np.dtype(arg_annotation.dtype)
+                    )
                     axes = [ax.name for ax in arg_annotation.axes]
                     data_dims = list(arg_annotation.data_dims)
                     fields_decls[arg_info.name] = nodes.FieldDecl(
@@ -2305,7 +2467,9 @@ class GTScriptParser(ast.NodeVisitor):
         for value in self.resolved_externals.values():
             if hasattr(value, "_gtscript_"):
                 assert callable(value)
-                func_node = gt_meta.get_ast(value, feature_version=PYTHON_AST_VERSION).body[0]
+                func_node = gt_meta.get_ast(
+                    value, feature_version=PYTHON_AST_VERSION
+                ).body[0]
                 local_context = self.resolve_external_symbols(
                     value._gtscript_["nonlocals"],
                     value._gtscript_["imported"],
@@ -2339,15 +2503,21 @@ class GTScriptParser(ast.NodeVisitor):
         DataDimLoopUnroller.apply(main_func_node, context=local_context)
 
         # Evaluate and inline compile-time conditionals
-        CompiledIfInliner.apply(main_func_node, context=local_context, stencil_name=self.main_name)
+        CompiledIfInliner.apply(
+            main_func_node, context=local_context, stencil_name=self.main_name
+        )
 
-        AssertionChecker.apply(main_func_node, context=local_context, source=self.source)
+        AssertionChecker.apply(
+            main_func_node, context=local_context, source=self.source
+        )
 
         temp_decls = _make_temp_decls(self.definition._gtscript_["temp_annotations"])
         fields_decls.update(temp_decls)
 
         init_computations = _make_init_computations(
-            temp_decls, self.definition._gtscript_["temp_init_values"], func_node=main_func_node
+            temp_decls,
+            self.definition._gtscript_["temp_init_values"],
+            func_node=main_func_node,
         )
 
         # Generate definition IR
@@ -2367,12 +2537,18 @@ class GTScriptParser(ast.NodeVisitor):
             domain=domain,
             api_signature=api_signature,
             api_fields=[
-                fields_decls[item.name] for item in api_signature if item.name in fields_decls
+                fields_decls[item.name]
+                for item in api_signature
+                if item.name in fields_decls
             ],
             parameters=[
-                parameter_decls[item.name] for item in api_signature if item.name in parameter_decls
+                parameter_decls[item.name]
+                for item in api_signature
+                if item.name in parameter_decls
             ],
-            computations=init_computations + computations if init_computations else computations,
+            computations=(
+                init_computations + computations if init_computations else computations
+            ),
             externals=self.resolved_externals,
             docstring=inspect.getdoc(self.definition) or "",
             loc=nodes.Location.from_ast_node(self.ast_root.body[0]),
@@ -2398,7 +2574,9 @@ class GTScriptFrontend(Frontend):
         }
         for name, value in definition._gtscript_["externals"].items():
             fingerprint[name] = (
-                value._gtscript_["canonical_ast"] if hasattr(value, "_gtscript_") else value
+                value._gtscript_["canonical_ast"]
+                if hasattr(value, "_gtscript_")
+                else value
             )
 
         definition_id = gt_utils.shashed_id(fingerprint)
@@ -2418,7 +2596,9 @@ class GTScriptFrontend(Frontend):
 
         if not hasattr(definition, "_gtscript_"):
             cls.prepare_stencil_definition(definition, externals)
-        translator = GTScriptParser(definition, externals=externals, dtypes=dtypes, options=options)
+        translator = GTScriptParser(
+            definition, externals=externals, dtypes=dtypes, options=options
+        )
         definition_ir = translator.run(backend_name)
 
         # GTIR only supports LatLonGrids

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -141,6 +141,7 @@ import sys
 from typing import List, Optional, Sequence
 
 import numpy as np
+import os
 
 from gt4py.cartesian.definitions import CartesianSpace
 from gt4py.cartesian.utils.attrib import (
@@ -289,6 +290,16 @@ DataType.FRONTEND_TO_NATIVE = {
     "i64": DataType.INT64,
     "f32": DataType.FLOAT32,
     "f64": DataType.FLOAT64,
+    "int": (
+        DataType.INT32
+        if int(os.getenv("GT4PY_LITERAL_PRECISION", "64")) == 32
+        else DataType.INT64
+    ),
+    "float": (
+        DataType.FLOAT32
+        if int(os.getenv("GT4PY_LITERAL_PRECISION", "64")) == "32"
+        else DataType.FLOAT64
+    ),
 }
 
 DataType.NATIVE_TYPE_TO_NUMPY = {
@@ -302,7 +313,9 @@ DataType.NATIVE_TYPE_TO_NUMPY = {
     DataType.FLOAT64: "float64",
 }
 
-DataType.NUMPY_TO_NATIVE_TYPE = {value: key for key, value in DataType.NATIVE_TYPE_TO_NUMPY.items()}
+DataType.NUMPY_TO_NATIVE_TYPE = {
+    value: key for key, value in DataType.NATIVE_TYPE_TO_NUMPY.items()
+}
 
 
 # ---- IR: expressions ----
@@ -363,10 +376,17 @@ class FieldRef(Ref):
 
     @classmethod
     def at_center(
-        cls, name: str, axes: Sequence[str], data_index: Optional[List[int]] = None, loc=None
+        cls,
+        name: str,
+        axes: Sequence[str],
+        data_index: Optional[List[int]] = None,
+        loc=None,
     ):
         return cls(
-            name=name, offset={axis: 0 for axis in axes}, data_index=data_index or [], loc=loc
+            name=name,
+            offset={axis: 0 for axis in axes},
+            data_index=data_index or [],
+            loc=loc,
         )
 
     @classmethod
@@ -739,12 +759,17 @@ class AxisInterval(Node):
         if not isinstance(self.start, AxisBound) or not isinstance(self.end, AxisBound):
             return False
 
-        return self.start.level == self.end.level and self.start.offset == self.end.offset - 1
+        return (
+            self.start.level == self.end.level
+            and self.start.offset == self.end.offset - 1
+        )
 
     def disjoint_from(self, other: AxisInterval) -> bool:
         def get_offset(bound: AxisBound) -> int:
             return (
-                0 + bound.offset if bound.level == LevelMarker.START else sys.maxsize + bound.offset
+                0 + bound.offset
+                if bound.level == LevelMarker.START
+                else sys.maxsize + bound.offset
             )
 
         self_start = get_offset(self.start)

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -69,6 +69,8 @@ TYPE_HINT_AND_CAST_BUILTINS = {
     "i64",
     "f32",
     "f64",
+    "int",
+    "float",
 }
 
 REDUCTION_BUILTINS = {"reduce", "add"}
@@ -137,13 +139,17 @@ def _set_arg_dtypes(definition: Callable[..., None], dtypes: Dict[Type, Type]):
         # arguments are annotated using instances (and not subclasses) of 'Field',
         # which is explicitly forbidden by 'get_type_hints()'.
         #
-        if isinstance(annotation, _FieldDescriptor) and isinstance(annotation.dtype, str):
+        if isinstance(annotation, _FieldDescriptor) and isinstance(
+            annotation.dtype, str
+        ):
             if annotation.dtype in dtypes:
                 return _FieldDescriptor(
                     dtypes[annotation.dtype], annotation.axes, annotation.data_dims
                 )
             else:
-                raise ValueError(f"Missing '{annotation.dtype}' dtype definition for arg '{arg}'")
+                raise ValueError(
+                    f"Missing '{annotation.dtype}' dtype definition for arg '{arg}'"
+                )
         elif isinstance(annotation, str):
             if annotation in dtypes:
                 return dtypes[annotation]
@@ -271,7 +277,9 @@ def stencil(
     if not isinstance(rebuild, bool):
         raise ValueError(f"Invalid 'rebuild' bool value ('{rebuild}')")
     if not isinstance(raise_if_not_cached, bool):
-        raise ValueError(f"Invalid 'raise_if_not_cached' bool value ('{raise_if_not_cached}')")
+        raise ValueError(
+            f"Invalid 'raise_if_not_cached' bool value ('{raise_if_not_cached}')"
+        )
     if cache_settings is not None and not isinstance(cache_settings, dict):
         raise ValueError(f"Invalid 'cache_settings' dictionary ('{cache_settings}')")
 
@@ -425,7 +433,9 @@ def lazy_stencil(
     if not isinstance(rebuild, bool):
         raise ValueError(f"Invalid 'rebuild' bool value ('{rebuild}')")
     if not isinstance(raise_if_not_cached, bool):
-        raise ValueError(f"Invalid 'raise_if_not_cached' bool value ('{raise_if_not_cached}')")
+        raise ValueError(
+            f"Invalid 'raise_if_not_cached' bool value ('{raise_if_not_cached}')"
+        )
 
     module = None
     if name:
@@ -448,7 +458,13 @@ def lazy_stencil(
 
     # Setup build_info timings
     if build_info is not None:
-        time_keys = ("parse_time", "module_time", "codegen_time", "build_time", "load_time")
+        time_keys = (
+            "parse_time",
+            "module_time",
+            "codegen_time",
+            "build_time",
+            "load_time",
+        )
         build_info.update({time_key: 0.0 for time_key in time_keys})
 
     build_options = gt_definitions.BuildOptions(
@@ -686,9 +702,7 @@ class _FieldDescriptor:
         return f"_FieldDescriptor({args})"
 
     def __str__(self) -> str:
-        return (
-            f"Field<[{', '.join(str(ax) for ax in self.axes)}], ({self.dtype}, {self.data_dims})>"
-        )
+        return f"Field<[{', '.join(str(ax) for ax in self.axes)}], ({self.dtype}, {self.data_dims})>"
 
     def at(self, *, K):
         """Stub function used to implement absolute
@@ -709,14 +723,18 @@ class _FieldDescriptorMaker:
         axes = IJK
         data_dims = ()
 
-        if isinstance(field_spec, str) or not isinstance(field_spec, collections.abc.Collection):
+        if isinstance(field_spec, str) or not isinstance(
+            field_spec, collections.abc.Collection
+        ):
             # Field[dtype] # noqa: ERA001 [commented-out-code]
             dtype = field_spec
         elif _FieldDescriptorMaker._is_axes_spec(field_spec[0]):
             # Field[axes, dtype] # noqa: ERA001 [commented-out-code]
             assert len(field_spec) == 2
             axes, dtype = field_spec
-        elif len(field_spec) == 2 and not _FieldDescriptorMaker._is_axes_spec(field_spec[1]):
+        elif len(field_spec) == 2 and not _FieldDescriptorMaker._is_axes_spec(
+            field_spec[1]
+        ):
             # Field[high_dimensional_dtype] # noqa: ERA001 [commented-out-code]
             dtype = field_spec
         else:
@@ -732,7 +750,10 @@ class _FieldDescriptorMaker:
 
 class _GlobalTableDescriptorMaker(_FieldDescriptorMaker):
     def __getitem__(self, field_spec):
-        if not isinstance(field_spec, collections.abc.Collection) and not len(field_spec) == 2:
+        if (
+            not isinstance(field_spec, collections.abc.Collection)
+            and not len(field_spec) == 2
+        ):
             raise ValueError("GlobalTable is defined by a tuple (type, [axes_size..])")
 
         dtype, data_dims = field_spec
@@ -816,8 +837,8 @@ def compile_assert(expr):
 # GTScript builtins: type cast & hints
 i32 = np.int32
 i64 = np.int64
-f64 = np.float64
 f32 = np.float32
+f64 = np.float64
 _gt_all_op_types = Union[i32, i64, f32, f64]
 
 


### PR DESCRIPTION
This feature adds the ability to cast to int/float, allowing the use of generic `int`/`float` instead of `i32`/`i64`/`f32`/`f64`.

Logic is done within the frontend, harnessing the existing NativeFunctions instead of creating new ones. Precision is determined by looking at the environment variable `GT4PY_LITERAL_PRECISION`, and is defaulted to 64.