### PR TITLE
feat[cartesian] Literal precision

### DIFF
--- a/src/gt4py/cartesian/definitions.py
+++ b/src/gt4py/cartesian/definitions.py
@@ -101,6 +101,7 @@ class BuildOptions(AttributeClassLike):
     rebuild = attribute(of=bool, default=False)
     raise_if_not_cached = attribute(of=bool, default=False)
     cache_settings = attribute(of=DictOf[str, Any], factory=dict)
+    literal_precision = attribute(of=int, default=64)
     _impl_opts = attribute(of=DictOf[str, Any], factory=dict)
 
     @property

--- a/src/gt4py/cartesian/definitions.py
+++ b/src/gt4py/cartesian/definitions.py
@@ -102,6 +102,8 @@ class BuildOptions(AttributeClassLike):
     raise_if_not_cached = attribute(of=bool, default=False)
     cache_settings = attribute(of=DictOf[str, Any], factory=dict)
     literal_precision = attribute(of=int, default=64)
+    "Specify the literal precision for automatic casts. Defaults to 64-bit"
+
     _impl_opts = attribute(of=DictOf[str, Any], factory=dict)
 
     @property

--- a/src/gt4py/cartesian/frontend/base.py
+++ b/src/gt4py/cartesian/frontend/base.py
@@ -95,7 +95,7 @@ class Frontend(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def prepare_stencil_definition(
-        cls, definition: AnyStencilFunc, externals: Dict[str, Any], options: BuildOptions = None
+        cls, definition: AnyStencilFunc, externals: dict[str, Any], options: BuildOptions = None
     ) -> AnnotatedStencilFunc:
         """
         Annotate the stencil function if not already done so.

--- a/src/gt4py/cartesian/frontend/base.py
+++ b/src/gt4py/cartesian/frontend/base.py
@@ -95,7 +95,7 @@ class Frontend(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def prepare_stencil_definition(
-        cls, definition: AnyStencilFunc, externals: dict[str, Any], options: BuildOptions = None
+        cls, definition: AnyStencilFunc, externals: dict[str, Any], options: BuildOptions | None = None
     ) -> AnnotatedStencilFunc:
         """
         Annotate the stencil function if not already done so.

--- a/src/gt4py/cartesian/frontend/base.py
+++ b/src/gt4py/cartesian/frontend/base.py
@@ -95,7 +95,7 @@ class Frontend(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def prepare_stencil_definition(
-        cls, definition: AnyStencilFunc, externals: Dict[str, Any]
+        cls, definition: AnyStencilFunc, externals: Dict[str, Any], options: BuildOptions = None
     ) -> AnnotatedStencilFunc:
         """
         Annotate the stencil function if not already done so.

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -16,6 +16,7 @@ import textwrap
 import time
 import types
 import warnings
+from collections.abc import Callable
 from typing import Any, Dict, Final, List, Literal, Optional, Sequence, Set, Tuple, Type, Union
 
 import numpy as np
@@ -968,6 +969,7 @@ class IRMaker(ast.NodeVisitor):
                 else nodes.NativeFunction.F64
             ),
         }
+        "Conversion table for functions to NativeFunctions."
 
         self.temporary_type_to_native_type = {
             "i32": nodes.DataType.INT32,
@@ -981,6 +983,7 @@ class IRMaker(ast.NodeVisitor):
             if options.literal_precision == 32
             else nodes.DataType.FLOAT64,
         }
+        "Conversion table for types to DataTypes."
 
     def __call__(self, ast_root: ast.AST):
         assert (
@@ -1977,8 +1980,25 @@ class GTScriptParser(ast.NodeVisitor):
 
     @staticmethod
     def annotate_definition(
-        definition, options: gt_definitions.BuildOptions = None, externals=None
-    ):
+        definition: Callable, options: gt_definitions.BuildOptions = None, externals=None
+    ) -> Callable:
+        """Annotate the function definition with dtypes, resolve externals and add default values.
+
+        Args:
+            definition (Callable): function to annotate
+            options (gt_definitions.BuildOptions, optional): Options for building the stencil.
+                Defaults to None.
+            externals (_type_, optional): Externals used.
+                Defaults to None.
+
+        Raises:
+            GTScriptDefinitionError
+            GTScriptValueError
+            GTScriptSyntaxError
+
+        Returns:
+            definition (Callable): function to annotate
+        """
         api_signature = []
         api_annotations = []
 
@@ -2443,8 +2463,19 @@ class GTScriptFrontend(Frontend):
 
     @classmethod
     def prepare_stencil_definition(
-        cls, definition, externals, options: gt_definitions.BuildOptions = None
-    ):
+        cls, definition: Callable, externals, options: gt_definitions.BuildOptions = None
+    ) -> Callable:
+        """Return an annotated version of the stencil definition.
+
+        Args:
+            definition (Callable): Stencil to annotate.
+            externals: externals to use
+            options (gt_definitions.BuildOptions, optional): Options for buidling the stencil.
+                Defaults to None.
+
+        Returns:
+            Callable: Annotated stencil
+        """
         return GTScriptParser.annotate_definition(definition, options, externals)
 
     @classmethod

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -2067,7 +2067,7 @@ class GTScriptParser(ast.NodeVisitor):
         temp_init_values: Dict[str, numbers.Number] = {}
 
         if options is not None:
-            frontent_types_to_native_types = nodes.frontend_type_to_native_type(
+            frontend_types_to_native_types = nodes.frontend_type_to_native_type(
                 options.literal_precision
             )
         else:

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -1980,7 +1980,7 @@ class GTScriptParser(ast.NodeVisitor):
 
     @staticmethod
     def annotate_definition(
-        definition: Callable, options: gt_definitions.BuildOptions = None, externals=None
+        definition: Callable, options: gt_definitions.BuildOptions | None = None, externals=None
     ) -> Callable:
         """Annotate the function definition with dtypes, resolve externals and add default values.
 

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -2463,7 +2463,7 @@ class GTScriptFrontend(Frontend):
 
     @classmethod
     def prepare_stencil_definition(
-        cls, definition: Callable, externals, options: gt_definitions.BuildOptions = None
+        cls, definition: Callable, externals, options: gt_definitions.BuildOptions | None = None
     ) -> Callable:
         """Return an annotated version of the stencil definition.
 

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -2094,7 +2094,7 @@ class GTScriptParser(ast.NodeVisitor):
             source = gt_meta.ast_unparse(ann_assign.annotation)
             descriptor = eval(source, ann_assign_context)
             # Scalar annotated are dealt with after inlining
-            if descriptor in frontent_types_to_native_types.values():
+            if descriptor in frontend_types_to_native_types.values():
                 continue
             temp_annotations[name] = descriptor
             if descriptor.axes != gtscript.IJK:

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -2084,7 +2084,7 @@ class GTScriptParser(ast.NodeVisitor):
             "JK": gtscript.JK,
             "np": np,
             **(resolved_externals if externals is not None else nonlocal_symbols),
-            **frontent_types_to_native_types,
+            **frontend_types_to_native_types,
         }
         ann_assigns = tuple(filter(lambda stmt: isinstance(stmt, ast.AnnAssign), ast_func_def.body))
         for ann_assign in ann_assigns:

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -2066,7 +2066,7 @@ class GTScriptParser(ast.NodeVisitor):
         temp_annotations: Dict[str, gtscript._FieldDescriptor] = {}
         temp_init_values: Dict[str, numbers.Number] = {}
 
-        if options:
+        if options is not None:
             frontent_types_to_native_types = nodes.frontend_type_to_native_type(
                 options.literal_precision
             )

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -2071,7 +2071,7 @@ class GTScriptParser(ast.NodeVisitor):
                 options.literal_precision
             )
         else:
-            frontent_types_to_native_types = nodes.frontend_type_to_native_type()
+            frontend_types_to_native_types = nodes.frontend_type_to_native_type()
 
         ann_assign_context = {
             "Field": gtscript.Field,

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -921,7 +921,7 @@ class IRMaker(ast.NodeVisitor):
         self.parsing_horizontal_region = False
         self.written_vars: Set[str] = set()
         self.dtypes = dtypes
-        nodes.NativeFunction.PYTHON_SYMBOL_TO_IR_OP = {
+        self.python_symbol_to_ir_op = {
             "abs": nodes.NativeFunction.ABS,
             "min": nodes.NativeFunction.MIN,
             "max": nodes.NativeFunction.MAX,
@@ -967,6 +967,19 @@ class IRMaker(ast.NodeVisitor):
                 if options.literal_precision == 32
                 else nodes.NativeFunction.F64
             ),
+        }
+
+        self.temporary_type_to_native_type = {
+            "i32": nodes.DataType.INT32,
+            "i64": nodes.DataType.INT64,
+            "f32": nodes.DataType.FLOAT32,
+            "f64": nodes.DataType.FLOAT64,
+            "int": nodes.DataType.INT32
+            if options.literal_precision == 32
+            else nodes.DataType.INT64,
+            "float": nodes.DataType.FLOAT32
+            if options.literal_precision == 32
+            else nodes.DataType.FLOAT64,
         }
 
     def __call__(self, ast_root: ast.AST):
@@ -1636,7 +1649,7 @@ class IRMaker(ast.NodeVisitor):
             return self._absolute_K_index_method(node)
 
         # We expect the Call is a native function to carry forward
-        native_fcn = nodes.NativeFunction.PYTHON_SYMBOL_TO_IR_OP[node.func.id]
+        native_fcn = self.python_symbol_to_ir_op[node.func.id]
 
         args = [self.visit(arg) for arg in node.args]
         if len(args) != native_fcn.arity:
@@ -1738,11 +1751,11 @@ class IRMaker(ast.NodeVisitor):
                     if target_annotation is not None:
                         source = gt_meta.ast_unparse(target_annotation)
                         try:
-                            dtype = eval(source, nodes.DataType.FRONTEND_TO_NATIVE)
+                            dtype = eval(source, self.temporary_type_to_native_type)
                         except NameError:
                             raise GTScriptSyntaxError(
                                 message=f"Failed to recognize type {source} for local symbol {name}."
-                                f"Available types are {nodes.DataType.FRONTEND_TO_NATIVE.keys()}",
+                                f"Available types are {self.temporary_type_to_native_type.keys()}",
                                 loc=nodes.Location.from_ast_node(t),
                             ) from None
                     field_decl = nodes.FieldDecl(
@@ -1963,7 +1976,9 @@ class GTScriptParser(ast.NodeVisitor):
         return result
 
     @staticmethod
-    def annotate_definition(definition, externals=None):
+    def annotate_definition(
+        definition, options: gt_definitions.BuildOptions = None, externals=None
+    ):
         api_signature = []
         api_annotations = []
 
@@ -2031,6 +2046,13 @@ class GTScriptParser(ast.NodeVisitor):
         temp_annotations: Dict[str, gtscript._FieldDescriptor] = {}
         temp_init_values: Dict[str, numbers.Number] = {}
 
+        if options:
+            frontent_types_to_native_types = nodes.frontend_type_to_native_type(
+                options.literal_precision
+            )
+        else:
+            frontent_types_to_native_types = nodes.frontend_type_to_native_type()
+
         ann_assign_context = {
             "Field": gtscript.Field,
             "IJK": gtscript.IJK,
@@ -2042,7 +2064,7 @@ class GTScriptParser(ast.NodeVisitor):
             "JK": gtscript.JK,
             "np": np,
             **(resolved_externals if externals is not None else nonlocal_symbols),
-            **nodes.DataType.FRONTEND_TO_NATIVE,
+            **frontent_types_to_native_types,
         }
         ann_assigns = tuple(filter(lambda stmt: isinstance(stmt, ast.AnnAssign), ast_func_def.body))
         for ann_assign in ann_assigns:
@@ -2052,7 +2074,7 @@ class GTScriptParser(ast.NodeVisitor):
             source = gt_meta.ast_unparse(ann_assign.annotation)
             descriptor = eval(source, ann_assign_context)
             # Scalar annotated are dealt with after inlining
-            if descriptor in nodes.DataType.FRONTEND_TO_NATIVE.values():
+            if descriptor in frontent_types_to_native_types.values():
                 continue
             temp_annotations[name] = descriptor
             if descriptor.axes != gtscript.IJK:
@@ -2420,8 +2442,10 @@ class GTScriptFrontend(Frontend):
         return stencil_id
 
     @classmethod
-    def prepare_stencil_definition(cls, definition, externals):
-        return GTScriptParser.annotate_definition(definition, externals)
+    def prepare_stencil_definition(
+        cls, definition, externals, options: gt_definitions.BuildOptions = None
+    ):
+        return GTScriptParser.annotate_definition(definition, options, externals)
 
     @classmethod
     def generate(cls, definition, externals, dtypes, options, backend_name):
@@ -2429,7 +2453,7 @@ class GTScriptFrontend(Frontend):
             start_time = time.perf_counter()
 
         if not hasattr(definition, "_gtscript_"):
-            cls.prepare_stencil_definition(definition, externals)
+            cls.prepare_stencil_definition(definition, externals, options)
         translator = GTScriptParser(definition, externals=externals, dtypes=dtypes, options=options)
         definition_ir = translator.run(backend_name)
 

--- a/src/gt4py/cartesian/frontend/gtscript_frontend.py
+++ b/src/gt4py/cartesian/frontend/gtscript_frontend.py
@@ -897,6 +897,7 @@ class IRMaker(ast.NodeVisitor):
         backend_name: str,
         *,
         domain: nodes.Domain,
+        options: gt_definitions.BuildOptions,
         temp_decls: Optional[Dict[str, nodes.FieldDecl]] = None,
         dtypes: Optional[Dict[Type, Type]] = None,
     ):
@@ -956,6 +957,16 @@ class IRMaker(ast.NodeVisitor):
             "i64": nodes.NativeFunction.I64,
             "f32": nodes.NativeFunction.F32,
             "f64": nodes.NativeFunction.F64,
+            "int": (
+                nodes.NativeFunction.I32
+                if options.literal_precision == 32
+                else nodes.NativeFunction.I64
+            ),
+            "float": (
+                nodes.NativeFunction.F32
+                if options.literal_precision == 32
+                else nodes.NativeFunction.F64
+            ),
         }
 
     def __call__(self, ast_root: ast.AST):
@@ -2360,6 +2371,7 @@ class GTScriptParser(ast.NodeVisitor):
             domain=domain,
             temp_decls=temp_decls,
             dtypes=self.dtypes,
+            options=self.options,
         )(self.ast_root)
 
         self.definition_ir = nodes.StencilDefinition(

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -285,6 +285,15 @@ class DataType(enum.Enum):
 
 
 def frontend_type_to_native_type(literal_precision: int = 64) -> dict[str, DataType]:
+    """Return the mapping of frontend types to native types.
+
+    Args:
+        literal_precision (int, optional): Literal precision used for mapping.
+            Defaults to 64.
+
+    Returns:
+        dict[str, DataType]: Mapping of the frontend types to our DataTypes.
+    """
     return {
         "i32": DataType.INT32,
         "i64": DataType.INT64,

--- a/src/gt4py/cartesian/frontend/nodes.py
+++ b/src/gt4py/cartesian/frontend/nodes.py
@@ -284,12 +284,16 @@ class DataType(enum.Enum):
         return result
 
 
-DataType.FRONTEND_TO_NATIVE = {
-    "i32": DataType.INT32,
-    "i64": DataType.INT64,
-    "f32": DataType.FLOAT32,
-    "f64": DataType.FLOAT64,
-}
+def frontend_type_to_native_type(literal_precision: int = 64) -> dict[str, DataType]:
+    return {
+        "i32": DataType.INT32,
+        "i64": DataType.INT64,
+        "int": DataType.INT32 if literal_precision == 32 else DataType.INT64,
+        "f32": DataType.FLOAT32,
+        "f64": DataType.FLOAT64,
+        "float": DataType.FLOAT32 if literal_precision == 32 else DataType.FLOAT64,
+    }
+
 
 DataType.NATIVE_TYPE_TO_NUMPY = {
     DataType.DEFAULT: "float_",

--- a/src/gt4py/cartesian/gtc/gtir.py
+++ b/src/gt4py/cartesian/gtc/gtir.py
@@ -57,7 +57,7 @@ class AbsoluteKIndex(common.AbsoluteKIndex[Expr]):
     pass
 
 
-class ScalarAccess(common.ScalarAccess, Expr):  # type: ignore
+class ScalarAccess(common.ScalarAccess, Expr):
     pass
 
 

--- a/src/gt4py/cartesian/gtscript.py
+++ b/src/gt4py/cartesian/gtscript.py
@@ -15,6 +15,7 @@ definitions for the keywords of the DSL.
 import collections
 import inspect
 import numbers
+import platform
 import types
 from typing import Callable, Dict, Type, Union
 
@@ -69,6 +70,8 @@ TYPE_HINT_AND_CAST_BUILTINS = {
     "i64",
     "f32",
     "f64",
+    "int",
+    "float",
 }
 
 REDUCTION_BUILTINS = {"reduce", "add"}
@@ -129,6 +132,10 @@ _VALID_DATA_TYPES = (
     np.float64,
 )
 
+# since platform.architecture() returns "('64bit', 'ELF')" for example, we extract the number from here
+ARCHITECTURE_LITERAL_PRECISION = int(platform.architecture()[0][:2])
+"literal precision of the architecture - 64 or 32"
+
 
 def _set_arg_dtypes(definition: Callable[..., None], dtypes: Dict[Type, Type]):
     def _parse_annotation(arg, annotation):
@@ -182,6 +189,7 @@ def stencil(
     rebuild=False,
     cache_settings=None,
     raise_if_not_cached=False,
+    literal_precision=ARCHITECTURE_LITERAL_PRECISION,
     **kwargs,
 ):
     """Generate an implementation of the stencil definition with the specified backend.
@@ -235,6 +243,10 @@ def stencil(
             - `root_path`: (str)
             - `dir_name`: (str)
 
+        literal_precision: `int` optional
+            Value to define the precision of generic casts `int` and `float`.
+            (System literal precision by default).
+
         **kwargs: `dict`, optional
             Extra backend-specific options. Check the specific backend
             documentation for further information.
@@ -274,6 +286,8 @@ def stencil(
         raise ValueError(f"Invalid 'raise_if_not_cached' bool value ('{raise_if_not_cached}')")
     if cache_settings is not None and not isinstance(cache_settings, dict):
         raise ValueError(f"Invalid 'cache_settings' dictionary ('{cache_settings}')")
+    if not isinstance(literal_precision, int) and literal_precision not in (32, 64):
+        raise ValueError(f"Invalid 'literal_precision' ('{literal_precision}')")
 
     module = None
     if name:
@@ -314,6 +328,7 @@ def stencil(
         backend_opts=kwargs,
         build_info=build_info,
         cache_settings=cache_settings or {},
+        literal_precision=literal_precision,
         impl_opts=_impl_opts,
     )
 

--- a/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
+++ b/tests/cartesian_tests/unit_tests/frontend_tests/test_gtscript_frontend.py
@@ -49,13 +49,19 @@ def parse_definition(
     module: str,
     externals: Optional[Dict[str, Any]] = None,
     dtypes: Dict[Type, Type] = None,
+    literal_precision=64,
     rebuild=False,
     **kwargs,
-):
+) -> nodes.StencilDefinition:
     original_annotations = gtscript._set_arg_dtypes(definition_func, dtypes=dtypes or {})
 
     build_options = gt_definitions.BuildOptions(
-        name=name, module=module, rebuild=rebuild, backend_opts=kwargs, build_info=None
+        name=name,
+        module=module,
+        rebuild=rebuild,
+        backend_opts=kwargs,
+        literal_precision=literal_precision,
+        build_info=None,
     )
 
     gt_frontend.GTScriptFrontend.prepare_stencil_definition(
@@ -1861,3 +1867,121 @@ class TestAbsoluteIndex:
                 name=inspect.stack()[0][3],
                 module=self.__class__.__name__,
             )
+
+
+class TestLiteralCasts:
+    def setup_method(self):
+        def float_cast(field: gtscript.Field[float]):  # type: ignore
+            with computation(PARALLEL), interval(0, 1):
+                field[0, 0, 0] = float(0)
+
+        def int_cast(field: gtscript.Field[float]):  # type: ignore
+            with computation(PARALLEL), interval(0, 1):
+                field[0, 0, 0] = int(0)
+
+        self.float_cast = float_cast
+        self.int_cast = int_cast
+
+    def test_explicit_64_int_cast(self):
+        def_ir = parse_definition(
+            self.int_cast,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_precision=64,
+        )
+        cast_call: nodes.NativeFuncCall = def_ir.computations[0].body.stmts[0].value
+        assert cast_call.func == nodes.NativeFunction.I64
+
+    def test_explicit_32_int_cast(self):
+        def_ir = parse_definition(
+            self.int_cast,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_precision=32,
+        )
+        cast_call: nodes.NativeFuncCall = def_ir.computations[0].body.stmts[0].value
+        assert cast_call.func == nodes.NativeFunction.I32
+
+    def test_explicit_32_float_cast(self):
+        def_ir = parse_definition(
+            self.float_cast,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_precision=32,
+        )
+        cast_call: nodes.NativeFuncCall = def_ir.computations[0].body.stmts[0].value
+        assert cast_call.func == nodes.NativeFunction.F32
+
+    def test_explicit_64_float_cast(self):
+        def_ir = parse_definition(
+            self.float_cast,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_precision=64,
+        )
+        cast_call: nodes.NativeFuncCall = def_ir.computations[0].body.stmts[0].value
+        assert cast_call.func == nodes.NativeFunction.F64
+
+
+class TestTemporaryTypes:
+    def setup_method(self):
+        def temporary_int_stencil(field: gtscript.Field[float]):  # type: ignore
+            with computation(PARALLEL), interval(0, 1):
+                temporary: int = 12
+                field[0, 0, 0] = temporary
+
+        def temporary_float_stencil(field: gtscript.Field[float]):  # type: ignore
+            with computation(PARALLEL), interval(0, 1):
+                temporary: float = 12
+                field[0, 0, 0] = temporary
+
+        self.int_stencil = temporary_int_stencil
+        self.float_stencil = temporary_float_stencil
+
+    def test_explicit_64_int_temp_defn(self):
+        def_ir = parse_definition(
+            self.int_stencil,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_precision=64,
+        )
+
+        print(def_ir)
+        field_declaration: nodes.FieldDecl = def_ir.computations[0].body.stmts[0]
+        assert field_declaration.data_type == nodes.DataType.INT64
+
+    def test_explicit_32_int_temp_defn(self):
+        def_ir = parse_definition(
+            self.int_stencil,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_precision=32,
+        )
+
+        print(def_ir)
+        field_declaration: nodes.FieldDecl = def_ir.computations[0].body.stmts[0]
+        assert field_declaration.data_type == nodes.DataType.INT32
+
+    def test_explicit_64_float_temp_defn(self):
+        def_ir = parse_definition(
+            self.float_stencil,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_precision=64,
+        )
+
+        print(def_ir)
+        field_declaration: nodes.FieldDecl = def_ir.computations[0].body.stmts[0]
+        assert field_declaration.data_type == nodes.DataType.FLOAT64
+
+    def test_explicit_32_float_temp_defn(self):
+        def_ir = parse_definition(
+            self.float_stencil,
+            name=inspect.stack()[0][3],
+            module=self.__class__.__name__,
+            literal_precision=32,
+        )
+
+        print(def_ir)
+        field_declaration: nodes.FieldDecl = def_ir.computations[0].body.stmts[0]
+        assert field_declaration.data_type == nodes.DataType.FLOAT32


### PR DESCRIPTION

## Description
As we realized there is more mixed-precision work in fv3, this PR allows for generic casts.

Allow for generic casts `int` and `float` to a literal precision that is given to any given stencil. This allows for better re-use instead of having to rely on the hard-coded `i32` and `i64` between stencils.
