### PR TITLE
Absolute K indexing fix: memlet volumn when mixed with cartesian

### DIFF
--- a/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
+++ b/src/gt4py/cartesian/gtc/dace/expansion/daceir_builder.py
@@ -867,6 +867,54 @@ class DaCeIRBuilder(eve.NodeTranslator):
             if isinstance(acc.offset, oir.VariableKOffset)
         }
 
+        # Book keep - field that will have absolute access in K, which therefore
+        # need an IndexAccess down the line rather than scalar
+        absolute_K_access_fields: Set[eve.SymbolRef] = {
+            acc.name
+            for acc in node.walk_values().if_isinstance(oir.FieldAccess)
+            if isinstance(acc.offset, common.AbsoluteKIndex)
+        }
+
+        # Welcome to another episode of "What the Hell is this workaround".
+        # Today, we are looking at cases where absolute read and cartesian writes
+        # live in the same vertical loop e.g.
+        # ```
+        #   with computation(PARALLEL), interval(...):
+        #       _ = field.abs(K=x)                      # noqa: ERA001
+        #       ...
+        #       field = a + b                           # noqa: ERA001
+        # ````
+        # This code is valid, the issue with DaCe bridge is that the volume given to
+        # the memlet differs in this case
+        #  - read memlet (absolute indexing): full array, we don't know
+        #  - write memlet (cartesian): 1 - we know exactly
+        # Since those apply to the same underlying array, DaCe is not too happy about it.
+        # The workaround is to use the "variable K offset" pipeline for the cartesian to
+        # match the wider volume and at the same time keep the relative index correct.
+        #
+        # It is dirty. Yes. I am ashamed. A little. But it'll go away (tm) in the new bridge.
+        #
+        # If you read this, and it hasn't, well, better get those refactor goggles on
+        # cause the entire indexing needs to be torched and rebuild.
+        #
+        # Cheerio,
+        # Florian
+        for acc in node.walk_values().if_isinstance(oir.FieldAccess):
+            if acc.name in absolute_K_access_fields:
+                if isinstance(acc.offset, common.CartesianOffset):
+                    if acc.offset.i != 0 or acc.offset.j != 0:
+                        raise NotImplementedError(
+                            "Flipping cartesian to variable K offset in case of"
+                            "an absolute K read in the same vertical loop is not implemented."
+                        )
+                    acc.offset = oir.VariableKOffset(
+                        k=oir.Literal(
+                            value=f"{acc.offset.k}",
+                            dtype=common.DataType.INT32,
+                            kind=common.ExprKind.SCALAR,
+                        )
+                    )
+
         # We book keep - all write offset to K
         K_write_with_offset = set()
         for assign_node in node.walk_values().if_isinstance(oir.AssignStmt):
@@ -876,14 +924,6 @@ class DaCeIRBuilder(eve.NodeTranslator):
                     and assign_node.left.offset.k != 0
                 ):
                     K_write_with_offset.add(assign_node.left.name)
-
-        # Book keep - field that will have absolute access in K, which therefore
-        # need an IndexAccess down the line rather than scalar
-        absolute_K_access_fields: Set[eve.SymbolRef] = {
-            acc.name
-            for acc in node.walk_values().if_isinstance(oir.FieldAccess)
-            if isinstance(acc.offset, common.AbsoluteKIndex)
-        }
 
         sections_idx = next(
             idx

--- a/tests/cartesian_tests/integration_tests/multi_feature_tests/test_debug_backend.py
+++ b/tests/cartesian_tests/integration_tests/multi_feature_tests/test_debug_backend.py
@@ -329,6 +329,32 @@ def test_absolute_k_stencil():
     np.testing.assert_allclose(field_out.view(np.ndarray)[:, :, :], 15)
 
 
+def test_absolute_k_read_cartesian_write_stencil():
+    field_inout = gt_storage.ones(
+        dtype=np.float64, backend="dace:cpu", shape=(4, 4, 4), aligned_index=(0, 0, 0)
+    )
+    field_out = gt_storage.zeros(
+        dtype=np.float64, backend="dace:cpu", shape=(4, 4, 4), aligned_index=(0, 0, 0)
+    )
+    field_inout[:, :, 0] *= 10
+    field_inout[:, :, 1] *= 5
+
+    @gtscript.stencil(backend="dace:cpu")
+    def test_stencil(
+        inout_field: gtscript.Field[np.float64],
+        out_bottom: gtscript.Field[np.float64],
+    ):
+        with computation(PARALLEL), interval(...):
+            out_bottom = inout_field.at(K=2)
+            inout_field = 23
+
+    test_stencil(field_inout, field_out)
+
+    assert (field_inout[1, 1, :] == [23.0, 23.0, 23.0, 23.0]).all()
+    assert (field_out[1, 1, :] == [1.0, 1.0, 1.0, 23.0]).all()
+    # np.testing.assert_allclose(field_out.view(np.ndarray)[:, :, :], 15)
+
+
 def test_k_only_access_stencil():
     field_in = np.ones((4,), dtype=np.float64)
     field_out = gt_storage.zeros(


### PR DESCRIPTION
As per inline comment:

Today, we are looking at cases where absolute read and cartesian writes live in the same vertical loop e.g.
```
  with computation(PARALLEL), interval(...):
      _ = field.abs(K=x)                      # noqa: ERA001
      ...
      field = a + b                           # noqa: ERA001
```
This code is valid, the issue with DaCe bridge is that the volume given to the memlet differs in this case:
  - read memlet (absolute indexing): full array, we don't know
  - write memlet (cartesian): 1 - we know exactly
Since those apply to the same underlying array, DaCe is not too happy about it. The workaround is to use the "variable K offset" pipeline for the cartesian to match the wider volume and at the same time keep the relative index correct.