### PR TITLE
Allow allocation of arrays with many gridpoints

### DIFF
--- a/src/gt4py/storage/allocators.py
+++ b/src/gt4py/storage/allocators.py
@@ -212,7 +212,7 @@ class _BaseNDArrayBufferAllocator(abc.ABC, Generic[core_defs.DeviceTypeT]):
         # Compute the padding required in the contiguous dimension to get aligned blocks
         dims_layout = [layout_map.index(i) for i in range(len(shape))]
         # Convert shape size to same data type (note that `np.int16` can overflow)
-        padded_shape_lst = [np.int32(x) for x in shape]
+        padded_shape_lst = [np.int64(x) for x in shape]
         if ndim > 0:
             padded_shape_lst[dims_layout[-1]] = (  # type: ignore[call-overload]
                 math.ceil(shape[dims_layout[-1]] / items_per_aligned_block)


### PR DESCRIPTION
This tiny pull request avoids overflow errors when computing the total number of grid points for an array. This overflow occurs for arrays with data dimensions where the number of grid points can become quite large.

The following computation caused overflow errors with `numpy.int32`:
```
                         here
                         |
total_length = item_size * functools.reduce(operator.mul, padded_shape, 1) + (
    byte_alignment - 1
)  # the worst case for misalignment is `byte_alignment - 1`
```